### PR TITLE
Add Unit tests for /api/user endpoints

### DIFF
--- a/gauchograduate/jest.config.js
+++ b/gauchograduate/jest.config.js
@@ -10,6 +10,11 @@ module.exports = {
   transform: {
     '^.+\\.(ts|tsx)$': ['ts-jest', {
       tsconfig: 'tsconfig.json',
+      useESM: true,
     }],
   },
+  transformIgnorePatterns: [
+    '/node_modules/(?!(@auth/prisma-adapter|next-auth|@prisma/client)/)'
+  ],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
 };

--- a/gauchograduate/jest.setup.js
+++ b/gauchograduate/jest.setup.js
@@ -1,3 +1,23 @@
+// Mock @auth/prisma-adapter
+jest.mock('@auth/prisma-adapter', () => ({
+  PrismaAdapter: jest.fn()
+}));
+
+// Mock next-auth
+jest.mock('next-auth', () => {
+  const originalModule = jest.requireActual('next-auth');
+  const nextAuth = jest.fn(() => Promise.resolve({ status: 200 }));
+  return {
+    __esModule: true,
+    ...originalModule,
+    default: nextAuth
+  };
+});
+
+jest.mock('next-auth/next', () => ({
+  getServerSession: jest.fn()
+}));
+
 // Mock the prisma client
 jest.mock('@/lib/prisma', () => ({
   prisma: {
@@ -9,5 +29,25 @@ jest.mock('@/lib/prisma', () => ({
       findUnique: jest.fn(),
       findMany: jest.fn(),
     },
+    user: {
+      findUnique: jest.fn().mockImplementation(() => ({
+        courses: {
+          firstQuarter: "20241",
+          courses: []
+        }
+      })),
+      update: jest.fn().mockImplementation((args) => ({
+        ...args.data,
+        id: '123'
+      })),
+    },
   },
 }));
+
+// Suppress console.error during tests
+global.console.error = jest.fn();
+
+// Reset all mocks before each test
+beforeEach(() => {
+  jest.clearAllMocks();
+});

--- a/gauchograduate/src/pages/api/knowledge.md
+++ b/gauchograduate/src/pages/api/knowledge.md
@@ -2,3 +2,18 @@
 
 ### Type Safety
 Because we are using typescript, we want to make sure that endpoints follow type rules. Make sure to note the types in app/components/coursetypes.ts as well as the types in types/next-auth.d.ts.
+
+### Testing
+- Use Jest for testing API endpoints
+- Tests are located in `__tests__` directories next to the files they test
+- Mock Prisma client and next-auth in jest.setup.js
+- Use node-mocks-http to simulate Next.js API requests
+- Test both success and error cases for each endpoint
+- Verify authentication checks
+- Check response status codes and data structure
+
+### User Course Endpoints
+Response formats:
+- GET /api/user/courses: Returns `{ firstQuarter: string, courses: Array<{id: string, quarter: string}> }`
+- POST /api/user/add-course: Returns `{ courses: { firstQuarter: string, courses: Array<{id: string, quarter: string}> } }`
+- POST /api/user/remove-course: Returns `{ courses: Array<{id: string, quarter: string}> }`

--- a/gauchograduate/src/pages/api/user/__tests__/user.test.ts
+++ b/gauchograduate/src/pages/api/user/__tests__/user.test.ts
@@ -1,0 +1,287 @@
+import { createMocks } from 'node-mocks-http';
+import { getServerSession } from "next-auth/next";
+import coursesHandler from '../courses';
+import addCourseHandler from '../add-course';
+import removeCourseHandler from '../remove-course';
+import updateProfileHandler from '../update-profile';
+import majorHandler from '../major';
+import { prisma } from '@/lib/prisma';
+
+jest.mock('next-auth/next', () => ({
+  getServerSession: jest.fn()
+}));
+
+describe('User API Endpoints', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('GET /api/user/courses', () => {
+    it('should return 401 if not authenticated', async () => {
+      const { req, res } = createMocks({
+        method: 'GET',
+      });
+
+      (getServerSession as jest.Mock).mockResolvedValueOnce(null);
+
+      await coursesHandler(req, res);
+
+      expect(res._getStatusCode()).toBe(401);
+      expect(JSON.parse(res._getData())).toEqual({
+        error: "Not authenticated"
+      });
+    });
+
+    it('should return user courses if authenticated', async () => {
+      const { req, res } = createMocks({
+        method: 'GET',
+      });
+
+      const mockCourses = {
+        firstQuarter: "20241",
+        courses: [{ id: "CMPSC 16", quarter: "20241" }]
+      };
+
+      (getServerSession as jest.Mock).mockResolvedValueOnce({
+        user: { id: '123' }
+      });
+
+      (prisma.user.findUnique as jest.Mock).mockResolvedValueOnce({
+        courses: mockCourses
+      });
+
+      await coursesHandler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(JSON.parse(res._getData())).toEqual(mockCourses);
+    });
+  });
+
+  describe('POST /api/user/add-course', () => {
+    it('should return 401 if not authenticated', async () => {
+      const { req, res } = createMocks({
+        method: 'POST',
+        body: {
+          id: "CMPSC 16",
+          quarter: "20241"
+        },
+      });
+
+      (getServerSession as jest.Mock).mockResolvedValueOnce(null);
+
+      await addCourseHandler(req, res);
+
+      expect(res._getStatusCode()).toBe(401);
+      expect(JSON.parse(res._getData())).toEqual({
+        error: "Not authenticated"
+      });
+    });
+
+    it('should add a course successfully', async () => {
+      const { req, res } = createMocks({
+        method: 'POST',
+        body: {
+          id: "CMPSC 16",
+          quarter: "20241"
+        },
+      });
+
+      (getServerSession as jest.Mock).mockResolvedValueOnce({
+        user: { id: '123' }
+      });
+
+      const existingCourses = {
+        firstQuarter: "20241",
+        courses: []
+      };
+
+      const updatedCourses = {
+        firstQuarter: "20241",
+        courses: [{ id: "CMPSC 16", quarter: "20241" }]
+      };
+
+      (prisma.user.findUnique as jest.Mock).mockResolvedValueOnce({
+        courses: existingCourses
+      });
+
+      (prisma.user.update as jest.Mock).mockResolvedValueOnce({
+        courses: updatedCourses
+      });
+
+      await addCourseHandler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(JSON.parse(res._getData())).toEqual({
+        courses: updatedCourses
+      });
+    });
+  });
+
+  describe('POST /api/user/remove-course', () => {
+    it('should return 401 if not authenticated', async () => {
+      const { req, res } = createMocks({
+        method: 'POST',
+        body: {
+          id: "CMPSC 16",
+          quarter: "20241"
+        },
+      });
+
+      (getServerSession as jest.Mock).mockResolvedValueOnce(null);
+
+      await removeCourseHandler(req, res);
+
+      expect(res._getStatusCode()).toBe(401);
+      expect(JSON.parse(res._getData())).toEqual({
+        error: "Not authenticated"
+      });
+    });
+
+    it('should remove a course successfully', async () => {
+      const { req, res } = createMocks({
+        method: 'POST',
+        body: {
+          id: "CMPSC 16",
+          quarter: "20241"
+        },
+      });
+
+      (getServerSession as jest.Mock).mockResolvedValueOnce({
+        user: { id: '123' }
+      });
+
+      const existingCourses = {
+        firstQuarter: "20241",
+        courses: [{ id: "CMPSC 16", quarter: "20241" }]
+      };
+
+      const updatedCourses = {
+        firstQuarter: "20241",
+        courses: []
+      };
+
+      (prisma.user.findUnique as jest.Mock).mockResolvedValueOnce({
+        courses: existingCourses
+      });
+
+      (prisma.user.update as jest.Mock).mockResolvedValueOnce({
+        courses: updatedCourses
+      });
+
+      await removeCourseHandler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(JSON.parse(res._getData())).toEqual({
+        courses: {
+          courses: [],
+          firstQuarter: "20241"
+        }
+      });
+    });
+  });
+
+  describe('POST /api/user/update-profile', () => {
+    it('should return 401 if not authenticated', async () => {
+      const { req, res } = createMocks({
+        method: 'POST',
+        body: {
+          majorId: 1,
+          firstQuarter: "20241"
+        },
+      });
+
+      (getServerSession as jest.Mock).mockResolvedValueOnce(null);
+
+      await updateProfileHandler(req, res);
+
+      expect(res._getStatusCode()).toBe(401);
+      expect(JSON.parse(res._getData())).toEqual({
+        error: "Not authenticated"
+      });
+    });
+
+    it('should update profile successfully', async () => {
+      const { req, res } = createMocks({
+        method: 'POST',
+        body: {
+          majorId: 1,
+          firstQuarter: "20241"
+        },
+      });
+
+      (getServerSession as jest.Mock).mockResolvedValueOnce({
+        user: { id: '123' }
+      });
+
+      (prisma.major.findUnique as jest.Mock).mockResolvedValueOnce({
+        id: 1,
+        name: "Computer Science"
+      });
+
+      (prisma.user.findUnique as jest.Mock).mockResolvedValueOnce({
+        courses: { firstQuarter: "20241", courses: [] }
+      });
+
+      (prisma.user.update as jest.Mock).mockResolvedValueOnce({
+        id: '123',
+        majorId: 1
+      });
+
+      await updateProfileHandler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(JSON.parse(res._getData())).toEqual({
+        user: {
+          id: '123',
+          majorId: 1
+        }
+      });
+    });
+  });
+
+  describe('GET /api/user/major', () => {
+    it('should return 401 if not authenticated', async () => {
+      const { req, res } = createMocks({
+        method: 'GET',
+      });
+
+      (getServerSession as jest.Mock).mockResolvedValueOnce(null);
+
+      await majorHandler(req, res);
+
+      expect(res._getStatusCode()).toBe(401);
+      expect(JSON.parse(res._getData())).toEqual({
+        error: "Not authenticated"
+      });
+    });
+
+    it('should return user major if authenticated', async () => {
+      const { req, res } = createMocks({
+        method: 'GET',
+      });
+
+      (getServerSession as jest.Mock).mockResolvedValueOnce({
+        user: { id: '123' }
+      });
+
+      const mockMajor = {
+        id: 1,
+        name: "Computer Science",
+        college: "ENGR",
+        requirements: [1, 2, 3]
+      };
+
+      (prisma.user.findUnique as jest.Mock).mockResolvedValueOnce({
+        majorId: 1,
+        major: mockMajor
+      });
+
+      await majorHandler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(JSON.parse(res._getData())).toEqual({
+        major: mockMajor
+      });
+    });
+  });
+});

--- a/team/TESTING.md
+++ b/team/TESTING.md
@@ -38,4 +38,3 @@ These checks run automatically on:
 The CI pipeline requires:
 - Node.js 20
 - All dependencies installed with `npm ci`
-- Environment variables configured in GitHub Secrets


### PR DESCRIPTION
Closes #93 
This PR adds unit tests for API user endpoints. Run tests with `npm test`.
<img width="472" alt="image" src="https://github.com/user-attachments/assets/e669f109-e0e2-455a-aa66-d6defd12e278" />
