### PR TITLE
Current and Past Quarters display in four-year-plan now functional

### DIFF
--- a/gauchograduate/src/app/components/course-popup.tsx
+++ b/gauchograduate/src/app/components/course-popup.tsx
@@ -1,0 +1,34 @@
+import { CoursePopupProps } from './coursetypes';
+
+export default function CoursePopup({ course, term, onClose, onDelete }: CoursePopupProps) {
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50" onClick={onClose}>
+      <div className="bg-white p-6 rounded-lg shadow-xl max-w-md w-full m-4" onClick={e => e.stopPropagation()}>
+        <h3 className="text-xl font-bold mb-4">{course.course_id}</h3>
+        <div className="space-y-3">
+          <p className="text-lg">{course.title}</p>
+          <p className="text-gray-600">{course.units} units</p>
+          <p className="text-sm text-gray-500">Term: {term}</p>
+          {course.generalEd.length > 0 && (
+            <div className="text-sm text-gray-500">
+              <p>General Education Requirements:</p>
+              <ul className="list-disc pl-5">
+                {course.generalEd.map((ge, index) => (
+                  <li key={index}>{ge.geCode} ({ge.geCollege})</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+        <div className="mt-6 flex justify-end">
+          <button
+            onClick={onDelete}
+            className="bg-red-500 text-white px-4 py-2 rounded hover:bg-red-600 transition-colors"
+          >
+            Delete Course
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/gauchograduate/src/app/components/coursetypes.ts
+++ b/gauchograduate/src/app/components/coursetypes.ts
@@ -37,7 +37,23 @@ export interface Course {
 
 // describing the student's entire 4-year schedule
 export type ScheduleType = {
-    [year in YearType]: {
-      [t in Term]: Course[];
-    };
+  [year in YearType]: {
+    [t in Term]: Course[];
   };
+};
+
+// CoursePopup props
+export interface CoursePopupProps {
+  course: Course;
+  term: Term;
+  onClose: () => void;
+  onDelete: () => void;
+}
+
+export interface FourYearPlanProps {
+  selectedYear: YearType;
+  setSelectedYear: React.Dispatch<React.SetStateAction<YearType>>;
+  studentSchedule: ScheduleType;
+  addCourse: (course: Course, term: Term) => void;
+  removeCourse: (course: Course, term: Term) => void;
+}

--- a/gauchograduate/src/app/components/four-year-plan.tsx
+++ b/gauchograduate/src/app/components/four-year-plan.tsx
@@ -55,80 +55,78 @@ export default function FourYearPlan({ selectedYear, setSelectedYear, studentSch
     <div className="h-full w-full p-4 bg-white rounded-lg shadow-lg flex flex-col overflow-auto max-h-screen">
       <div className="flex justify-between items-center mb-4">
         <h2 className="text-xl font-semibold">Four-Year Plan</h2>
-        <div className="flex items-center gap-4">
-          <label className="flex items-center gap-2 text-sm">
-            <input
-              type="checkbox"
-              checked={showSummer}
-              onChange={(e) => setShowSummer(e.target.checked)}
-              className="rounded border-gray-300"
-            />
-            Show Summer Quarter
-          </label>
-          <select 
-            className="p-2 border border-gray-300 rounded-lg" 
-            value={selectedYear}
-            onChange={(e) => setSelectedYear(e.target.value as YearType)}
-          >
-            {Years.map((year, index) => (
-              <option key={index} value={year}>
-                {getYearDisplay(year)}
-              </option>
-            ))}
-          </select>
-        </div>
+        <select 
+          className="p-2 border border-gray-300 rounded-lg" 
+          value={selectedYear}
+          onChange={(e) => setSelectedYear(e.target.value as YearType)}
+        >
+          {Years.map((year, index) => (
+            <option key={index} value={year}>
+              {getYearDisplay(year)}
+            </option>
+          ))}
+        </select>
       </div>
 
-      <div className={`grid grid-cols-1 ${showSummer ? 'md:grid-cols-4' : 'md:grid-cols-3'} gap-2 flex-grow border border-gray-300 rounded-md p-2 bg-gray-50 min-h-0 overflow-y-auto`}>
-        {displayTerms.map((term) => (
-          <div
-            key={term}
-            onDragOver={(e) => e.preventDefault()}
-            onDrop={(e) => handleDrop(e, term)}
-            className="flex flex-col h-full justify-between p-4 border border-gray-300 rounded-lg bg-white"
-          >
-            <div className="flex-grow">
-              <h3 className="text-lg font-semibold text-center mb-4">{term}</h3>
-              <div className="flex flex-col gap-4">
-                {studentSchedule[selectedYear][term].length > 0 ? (
-                  studentSchedule[selectedYear][term].map((course) => {
-                    const bgColorClass = course.generalEd.length === 0  ? "bg-[var(--pale-orange)]" : "bg-[var(--pale-pink)]"; 
-                    return (
-                    <div 
-                      key={course.course_id}
-                      draggable = {true}
-                      onDragStart={(e) => {
-                        const courseData = { ...course, originTerm: term };
-                        e.dataTransfer.setData("application/json", JSON.stringify(courseData));
-                      }}
-                      className={`relative p-4 ${bgColorClass} rounded-lg group whitespace-normal break-words`}
-                    >
-                      <p className="font-bold text-sm">{course.course_id}</p>
-                      <p className="text-xs">{course.title}</p>
-                      <p className="text-xs text-gray-500">{course.units} units</p>
-                      <button
-                        className="bg-red-500 text-white p-1 rounded-full opacity-0 group-hover:opacity-100"
-                        onClick={() => removeCourse(course, term)}
+      <div className="flex gap-2 flex-1 min-h-0">
+        <div className={`grid grid-cols-1 ${showSummer ? 'md:grid-cols-4' : 'md:grid-cols-3'} gap-2 flex-grow border border-gray-300 rounded-md p-2 bg-gray-50 min-h-0 overflow-y-auto`}>
+          {displayTerms.map((term) => (
+            <div
+              key={term}
+              onDragOver={(e) => e.preventDefault()}
+              onDrop={(e) => handleDrop(e, term)}
+              className="flex flex-col h-full justify-between p-4 border border-gray-300 rounded-lg bg-white"
+            >
+              <div className="flex-grow">
+                <h3 className="text-lg font-semibold text-center mb-4">{term}</h3>
+                <div className="flex flex-col gap-4">
+                  {studentSchedule[selectedYear][term].length > 0 ? (
+                    studentSchedule[selectedYear][term].map((course) => {
+                      const bgColorClass = course.generalEd.length === 0  ? "bg-[var(--pale-orange)]" : "bg-[var(--pale-pink)]"; 
+                      return (
+                      <div 
+                        key={course.course_id}
+                        draggable = {true}
+                        onDragStart={(e) => {
+                          const courseData = { ...course, originTerm: term };
+                          e.dataTransfer.setData("application/json", JSON.stringify(courseData));
+                        }}
+                        className={`relative p-4 ${bgColorClass} rounded-lg group whitespace-normal break-words`}
                       >
-                        <DeleteIcon fontSize="small" />
-                      </button>
-                    </div>
-                  );})
-                ) : (
-                  <p className="text-xs text-gray-500 text-center">No courses</p>
-                )}
+                        <p className="font-bold text-sm">{course.course_id}</p>
+                        <p className="text-xs">{course.title}</p>
+                        <p className="text-xs text-gray-500">{course.units} units</p>
+                        <button
+                          className="bg-red-500 text-white p-1 rounded-full opacity-0 group-hover:opacity-100"
+                          onClick={() => removeCourse(course, term)}
+                        >
+                          <DeleteIcon fontSize="small" />
+                        </button>
+                      </div>
+                    );})
+                  ) : (
+                    <p className="text-xs text-gray-500 text-center">No courses</p>
+                  )}
+                </div>
+                <div className="mt-4 p-4 border-dashed border-2 border-gray-300 rounded-lg text-center text-sm text-gray-400">
+                  Drop Course Here
+                </div>
               </div>
-              <div className="mt-4 p-4 border-dashed border-2 border-gray-300 rounded-lg text-center text-sm text-gray-400">
-                Drop Course Here
+              <div className="mt-6 text-right">
+                <p className="font-light">
+                  Total units: <span className="font-light"> {studentSchedule[selectedYear][term].reduce((sum, course) => sum + course.units, 0)}</span>
+                </p>
               </div>
             </div>
-            <div className="mt-6 text-right">
-              <p className="font-light">
-                Total units: <span className="font-light"> {studentSchedule[selectedYear][term].reduce((sum, course) => sum + course.units, 0)}</span>
-              </p>
-            </div>
-          </div>
-        ))}
+          ))}
+        </div>
+        
+        <button
+          onClick={() => setShowSummer(!showSummer)}
+          className="writing-mode-vertical px-2 py-4 bg-[var(--pale-blue)] text-black rounded-lg transition-colors whitespace-nowrap h-auto"
+        >
+          {showSummer ? 'Hide Summer Quarter' : 'Show Summer Quarter'}
+        </button>
       </div>
     </div>
   );

--- a/gauchograduate/src/app/components/four-year-plan.tsx
+++ b/gauchograduate/src/app/components/four-year-plan.tsx
@@ -1,6 +1,7 @@
 import DeleteIcon from '@mui/icons-material/Delete'
 import { useSession } from 'next-auth/react';
 import { Terms, Years, Course, ScheduleType, YearType, Term } from "./coursetypes";
+import { useState } from 'react';
 
 interface FourYearPlanProps {
   selectedYear: YearType;
@@ -10,7 +11,6 @@ interface FourYearPlanProps {
   removeCourse: (course: Course, term: Term) => void;
 }
 
-// converts quarter code '20224' to string '22-'23
 export function getAcademicYear(quarterCode: string, yearOffset: number = 0): string {
   const year = parseInt(quarterCode.substring(0, 4));
   const shortYear = (year + yearOffset).toString().slice(2);
@@ -20,9 +20,9 @@ export function getAcademicYear(quarterCode: string, yearOffset: number = 0): st
 
 export default function FourYearPlan({ selectedYear, setSelectedYear, studentSchedule, addCourse, removeCourse}: FourYearPlanProps) { 
   const { data: session } = useSession();
-  const firstQuarter = session?.user?.courses?.firstQuarter || '20234'; // Default to Fall 2022
+  const firstQuarter = session?.user?.courses?.firstQuarter || '20234';
+  const [showSummer, setShowSummer] = useState(false);
   
-  // Function to get the display text for the year selector
   const getYearDisplay = (year: YearType): string => {
     const yearIndex = Years.indexOf(year);
     return getAcademicYear(firstQuarter, yearIndex);
@@ -49,25 +49,38 @@ export default function FourYearPlan({ selectedYear, setSelectedYear, studentSch
     addCourse(course, term as Term);
   }
 
+  const displayTerms = Terms.filter(term => term !== 'Summer' || showSummer);
+
   return (
     <div className="h-full w-full p-4 bg-white rounded-lg shadow-lg flex flex-col overflow-auto max-h-screen">
       <div className="flex justify-between items-center mb-4">
         <h2 className="text-xl font-semibold">Four-Year Plan</h2>
-        <select 
-        className="p-2 border border-gray-300 rounded-lg" 
-        value={selectedYear}
-        onChange={(e) => setSelectedYear(e.target.value as YearType)}
-        >
-          {Years.map((year, index) => (
-            <option key={index} value={year}>
-              {getYearDisplay(year)}
-            </option>
-          ))}
-        </select>
+        <div className="flex items-center gap-4">
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={showSummer}
+              onChange={(e) => setShowSummer(e.target.checked)}
+              className="rounded border-gray-300"
+            />
+            Show Summer Quarter
+          </label>
+          <select 
+            className="p-2 border border-gray-300 rounded-lg" 
+            value={selectedYear}
+            onChange={(e) => setSelectedYear(e.target.value as YearType)}
+          >
+            {Years.map((year, index) => (
+              <option key={index} value={year}>
+                {getYearDisplay(year)}
+              </option>
+            ))}
+          </select>
+        </div>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-2 flex-grow border border-gray-300 rounded-md p-2 bg-gray-50 min-h-0 overflow-y-auto">
-        {Terms.map((term) => (
+      <div className={`grid grid-cols-1 ${showSummer ? 'md:grid-cols-4' : 'md:grid-cols-3'} gap-2 flex-grow border border-gray-300 rounded-md p-2 bg-gray-50 min-h-0 overflow-y-auto`}>
+        {displayTerms.map((term) => (
           <div
             key={term}
             onDragOver={(e) => e.preventDefault()}

--- a/gauchograduate/src/app/components/utils/quarterUtils.ts
+++ b/gauchograduate/src/app/components/utils/quarterUtils.ts
@@ -1,0 +1,57 @@
+import { Term } from '../coursetypes';
+
+export function getAcademicYear(quarterCode: string, yearOffset: number = 0): string {
+  const year = parseInt(quarterCode.substring(0, 4));
+  const shortYear = (year + yearOffset).toString().slice(2);
+  const nextYear = ((year + yearOffset + 1) % 100).toString().padStart(2, '0');
+  return `'${shortYear}-'${nextYear}`;
+}
+
+export function getCurrentQuarter(): { quarter: Term; academicYear: string } {
+  const now = new Date();
+  const year = now.getFullYear();
+  
+  // Define quarter date ranges (from 2024-2025 schedule for right now)
+  const fallStart = new Date(year, 8, 22);  // Sep 22
+  const winterStart = new Date(year, 0, 6); // Jan 6
+  const springStart = new Date(year, 2, 31); // Mar 31
+  const summerStart = new Date(year, 5, 23); // Jun 23
+
+  let quarter: Term;
+  let academicYear: string;
+
+  if (now >= fallStart || now < winterStart) {
+    quarter = 'Fall';
+    academicYear = now >= fallStart ? `'${year.toString().slice(2)}-'${(year + 1).toString().slice(2)}` 
+                                  : `'${(year - 1).toString().slice(2)}-'${year.toString().slice(2)}`;
+  } else if (now >= winterStart && now < springStart) {
+    quarter = 'Winter';
+    academicYear = `'${(year - 1).toString().slice(2)}-'${year.toString().slice(2)}`;
+  } else if (now >= springStart && now < summerStart) {
+    quarter = 'Spring';
+    academicYear = `'${(year - 1).toString().slice(2)}-'${year.toString().slice(2)}`;
+  } else {
+    quarter = 'Summer';
+    academicYear = `'${(year - 1).toString().slice(2)}-'${year.toString().slice(2)}`;
+  }
+
+  return { quarter, academicYear };
+}
+
+export function isQuarterInPast(yearDisplay: string, term: Term): boolean {
+  const current = getCurrentQuarter();
+  const currentYear = parseInt(current.academicYear.slice(1, 3));
+  const yearToCheck = parseInt(yearDisplay.slice(1, 3));
+
+  if (yearToCheck < currentYear) return true;
+  if (yearToCheck > currentYear) return false;
+
+  // If in same year, check quarters
+  const quarterOrder: Record<Term, number> = { 'Fall': 0, 'Winter': 1, 'Spring': 2, 'Summer': 3 };
+  return quarterOrder[term] < quarterOrder[current.quarter];
+}
+
+export function isCurrentQuarter(yearDisplay: string, term: Term): boolean {
+  const current = getCurrentQuarter();
+  return yearDisplay === current.academicYear && term === current.quarter;
+}

--- a/gauchograduate/src/app/globals.css
+++ b/gauchograduate/src/app/globals.css
@@ -17,6 +17,12 @@ body {
   background: var(--background);
 }
 
+.writing-mode-vertical {
+  writing-mode: vertical-lr;
+  text-orientation: mixed;
+  transform: rotate(360deg);
+}
+
 /* @media (prefers-color-scheme: dark) {
   :root {
     --background: #0a0a0a;

--- a/gauchograduate/src/pages/test.tsx
+++ b/gauchograduate/src/pages/test.tsx
@@ -104,6 +104,15 @@ export default function TestPage() {
     }
   };
 
+  const mockSession = {
+    user: {
+      courses: {
+        firstQuarter: '20224', // Fall 2022
+        courses: []
+      }
+    }
+  };
+
   const addCourse = (course: Course, term: Term) => {
     setStudentSchedule((prevSchedule) => ({
       ...prevSchedule,

--- a/gauchograduate/src/pages/test.tsx
+++ b/gauchograduate/src/pages/test.tsx
@@ -104,15 +104,6 @@ export default function TestPage() {
     }
   };
 
-  const mockSession = {
-    user: {
-      courses: {
-        firstQuarter: '20224', // Fall 2022
-        courses: []
-      }
-    }
-  };
-
   const addCourse = (course: Course, term: Term) => {
     setStudentSchedule((prevSchedule) => ({
       ...prevSchedule,


### PR DESCRIPTION
Closes #94.

Four year plan now shows year based on user's inputted First Quarter in their profile (default to fall 2023).
Quarters that have been completed have a green background, the current quarter has a blue background, future quarters are white.

Used a utils folder and quarterUtils.tsx for the calculation of the current quarter/past quarters. Used the 2024-2025 calendar dates as a default (shouldn't be too much of a difference from past/future years).

minor UI fixes:
- summer quarter can be opened/closed (most students won't take summer classes)
- clicking on courses leads to a popup that allows deletion (very basic UI)