### PR TITLE
Create API endpoints for grades and overrides

### DIFF
--- a/gauchograduate/src/pages/api/knowledge.md
+++ b/gauchograduate/src/pages/api/knowledge.md
@@ -29,10 +29,10 @@ Response formats:
 
 ### Override Endpoints
 - POST /api/user/add-override: Adds a major requirement override to the user's courses
-  - Request body: `{ override: object }` - The override object format is determined by another team member
+  - Request body: `{ override: object }` - The override object to add
   - Response: `{ overrides: Array<any> }` - The updated array of overrides
 - POST /api/user/remove-override: Removes a major requirement override from the user's courses
-  - Request body: `{ index: number }` - The index of the override to remove
+  - Request body: `{ override: object }` - The override object to remove
   - Response: `{ overrides: Array<any> }` - The updated array of overrides
 
 ### E2E Testing with Playwright

--- a/gauchograduate/src/pages/api/knowledge.md
+++ b/gauchograduate/src/pages/api/knowledge.md
@@ -26,6 +26,14 @@ Response formats:
 - POST /api/user/remove-course: Returns `{ courses: Array<{id: string, quarter: string}> }`
 - POST /api/user/add-override: Returns `{ overrides: Array<any> }`
 - POST /api/user/remove-override: Returns `{ overrides: Array<any> }`
+- POST /api/user/courses/set-grade: Returns `{ success: boolean, courses: Array<{id: number, quarter: string, grade?: string}> }`
+
+### Grade Endpoint
+- POST /api/user/courses/set-grade: Sets a grade for a specific course in the user's course list
+  - Request body: `{ id: number, quarter: string, grade: string | null }`
+  - Valid grades: "A+", "A", "A-", "B+", "B", "B-", "C+", "C", "C-", "D+", "D", "D-", "F", "P", "NP"
+  - If grade is null, the grade property is removed from the course
+  - Response: `{ success: boolean, courses: Array<{id: number, quarter: string, grade?: string}> }`
 
 ### Override Endpoints
 - POST /api/user/add-override: Adds a major requirement override to the user's courses

--- a/gauchograduate/src/pages/api/knowledge.md
+++ b/gauchograduate/src/pages/api/knowledge.md
@@ -3,6 +3,13 @@
 ### Type Safety
 Because we are using typescript, we want to make sure that endpoints follow type rules. Make sure to note the types in app/components/coursetypes.ts as well as the types in types/next-auth.d.ts.
 
+### JSON Handling in Prisma
+When working with JSON fields in Prisma:
+- Always cast JSON data from Prisma as `unknown` first, then to your expected type: `data as unknown as YourType`
+- When updating JSON fields, use `JSON.parse(JSON.stringify(data))` to ensure proper serialization
+- This prevents type errors when working with complex nested objects in JSON fields
+- When modifying nested JSON data, always preserve all existing fields (like overrides and firstQuarter) to avoid data loss
+
 ### Testing
 - Use Jest for testing API endpoints
 - Tests are located in `__tests__` directories next to the files they test
@@ -17,6 +24,16 @@ Response formats:
 - GET /api/user/courses: Returns `{ firstQuarter: string, courses: Array<{id: string, quarter: string}> }`
 - POST /api/user/add-course: Returns `{ courses: { firstQuarter: string, courses: Array<{id: string, quarter: string}> } }`
 - POST /api/user/remove-course: Returns `{ courses: Array<{id: string, quarter: string}> }`
+- POST /api/user/add-override: Returns `{ overrides: Array<any> }`
+- POST /api/user/remove-override: Returns `{ overrides: Array<any> }`
+
+### Override Endpoints
+- POST /api/user/add-override: Adds a major requirement override to the user's courses
+  - Request body: `{ override: object }` - The override object format is determined by another team member
+  - Response: `{ overrides: Array<any> }` - The updated array of overrides
+- POST /api/user/remove-override: Removes a major requirement override from the user's courses
+  - Request body: `{ index: number }` - The index of the override to remove
+  - Response: `{ overrides: Array<any> }` - The updated array of overrides
 
 ### E2E Testing with Playwright
 - When testing OAuth flows, avoid simulating the full OAuth redirect flow

--- a/gauchograduate/src/pages/api/user/__tests__/user.test.ts
+++ b/gauchograduate/src/pages/api/user/__tests__/user.test.ts
@@ -5,6 +5,8 @@ import addCourseHandler from '../add-course';
 import removeCourseHandler from '../remove-course';
 import updateProfileHandler from '../update-profile';
 import majorHandler from '../major';
+import addOverrideHandler from '../add-override';
+import removeOverrideHandler from '../remove-override';
 import { prisma } from '@/lib/prisma';
 
 jest.mock('next-auth/next', () => ({
@@ -281,6 +283,375 @@ describe('User API Endpoints', () => {
       expect(res._getStatusCode()).toBe(200);
       expect(JSON.parse(res._getData())).toEqual({
         major: mockMajor
+      });
+    });
+  });
+
+  describe('POST /api/user/add-override', () => {
+    it('should return 401 if not authenticated', async () => {
+      const { req, res } = createMocks({
+        method: 'POST',
+        body: {
+          override: { type: 'major', requirement: 'specific-course', courseId: 1 }
+        },
+      });
+
+      (getServerSession as jest.Mock).mockResolvedValueOnce(null);
+
+      await addOverrideHandler(req, res);
+
+      expect(res._getStatusCode()).toBe(401);
+      expect(JSON.parse(res._getData())).toEqual({
+        error: "Not authenticated"
+      });
+    });
+
+    it('should add a major specific-course override successfully', async () => {
+      const { req, res } = createMocks({
+        method: 'POST',
+        body: {
+          override: { type: 'major', requirement: 'specific-course', courseId: 1 }
+        },
+      });
+
+      (getServerSession as jest.Mock).mockResolvedValueOnce({
+        user: { id: '123' }
+      });
+
+      const existingCourses = {
+        firstQuarter: "20241",
+        courses: [],
+        overrides: []
+      };
+
+      const updatedCourses = {
+        firstQuarter: "20241",
+        courses: [],
+        overrides: [{ type: 'major', requirement: 'specific-course', courseId: 1 }]
+      };
+
+      (prisma.user.findUnique as jest.Mock).mockResolvedValueOnce({
+        courses: existingCourses
+      });
+
+      (prisma.user.update as jest.Mock).mockResolvedValueOnce({
+        courses: updatedCourses
+      });
+
+      await addOverrideHandler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(JSON.parse(res._getData())).toEqual({
+        overrides: updatedCourses.overrides
+      });
+    });
+
+    it('should add a ge override successfully', async () => {
+      const { req, res } = createMocks({
+        method: 'POST',
+        body: {
+          override: { type: 'ge', requirement: 'WRT' }
+        },
+      });
+
+      (getServerSession as jest.Mock).mockResolvedValueOnce({
+        user: { id: '123' }
+      });
+
+      const existingCourses = {
+        firstQuarter: "20241",
+        courses: [],
+        overrides: []
+      };
+
+      const updatedCourses = {
+        firstQuarter: "20241",
+        courses: [],
+        overrides: [{ type: 'ge', requirement: 'WRT' }]
+      };
+
+      (prisma.user.findUnique as jest.Mock).mockResolvedValueOnce({
+        courses: existingCourses
+      });
+
+      (prisma.user.update as jest.Mock).mockResolvedValueOnce({
+        courses: updatedCourses
+      });
+
+      await addOverrideHandler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(JSON.parse(res._getData())).toEqual({
+        overrides: updatedCourses.overrides
+      });
+    });
+
+    it('should add a major elective override successfully', async () => {
+      const { req, res } = createMocks({
+        method: 'POST',
+        body: {
+          override: { type: 'major', requirement: 'elective' }
+        },
+      });
+
+      (getServerSession as jest.Mock).mockResolvedValueOnce({
+        user: { id: '123' }
+      });
+
+      const existingCourses = {
+        firstQuarter: "20241",
+        courses: [],
+        overrides: []
+      };
+
+      const updatedCourses = {
+        firstQuarter: "20241",
+        courses: [],
+        overrides: [{ type: 'major', requirement: 'elective' }]
+      };
+
+      (prisma.user.findUnique as jest.Mock).mockResolvedValueOnce({
+        courses: existingCourses
+      });
+
+      (prisma.user.update as jest.Mock).mockResolvedValueOnce({
+        courses: updatedCourses
+      });
+
+      await addOverrideHandler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(JSON.parse(res._getData())).toEqual({
+        overrides: updatedCourses.overrides
+      });
+    });
+
+    it('should initialize overrides array if it does not exist', async () => {
+      const { req, res } = createMocks({
+        method: 'POST',
+        body: {
+          override: { type: 'major', requirement: 'specific-course', courseId: 1 }
+        },
+      });
+
+      (getServerSession as jest.Mock).mockResolvedValueOnce({
+        user: { id: '123' }
+      });
+
+      const existingCourses = {
+        firstQuarter: "20241",
+        courses: []
+      };
+
+      const updatedCourses = {
+        firstQuarter: "20241",
+        courses: [],
+        overrides: [{ type: 'major', requirement: 'specific-course', courseId: 1 }]
+      };
+
+      (prisma.user.findUnique as jest.Mock).mockResolvedValueOnce({
+        courses: existingCourses
+      });
+
+      (prisma.user.update as jest.Mock).mockResolvedValueOnce({
+        courses: updatedCourses
+      });
+
+      await addOverrideHandler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(JSON.parse(res._getData())).toEqual({
+        overrides: updatedCourses.overrides
+      });
+    });
+
+    it('should return 400 if override is missing required fields', async () => {
+      const { req, res } = createMocks({
+        method: 'POST',
+        body: {
+          override: { type: 'major' } // Missing requirement field
+        },
+      });
+
+      (getServerSession as jest.Mock).mockResolvedValueOnce({
+        user: { id: '123' }
+      });
+
+      await addOverrideHandler(req, res);
+
+      expect(res._getStatusCode()).toBe(400);
+      expect(JSON.parse(res._getData())).toEqual({
+        error: "Override must include 'type' and 'requirement' fields"
+      });
+    });
+
+    it('should return 400 if specific-course override is missing courseId', async () => {
+      const { req, res } = createMocks({
+        method: 'POST',
+        body: {
+          override: { type: 'major', requirement: 'specific-course' } // Missing courseId
+        },
+      });
+
+      (getServerSession as jest.Mock).mockResolvedValueOnce({
+        user: { id: '123' }
+      });
+
+      await addOverrideHandler(req, res);
+
+      expect(res._getStatusCode()).toBe(400);
+      expect(JSON.parse(res._getData())).toEqual({
+        error: "courseId is required for specific-course requirements"
+      });
+    });
+  });
+
+  describe('POST /api/user/remove-override', () => {
+    it('should return 401 if not authenticated', async () => {
+      const { req, res } = createMocks({
+        method: 'POST',
+        body: {
+          override: { type: 'major', requirement: 'specific-course', courseId: 1 }
+        },
+      });
+
+      (getServerSession as jest.Mock).mockResolvedValueOnce(null);
+
+      await removeOverrideHandler(req, res);
+
+      expect(res._getStatusCode()).toBe(401);
+      expect(JSON.parse(res._getData())).toEqual({
+        error: "Not authenticated"
+      });
+    });
+
+    it('should remove a major specific-course override successfully', async () => {
+      const { req, res } = createMocks({
+        method: 'POST',
+        body: {
+          override: { type: 'major', requirement: 'specific-course', courseId: 1 }
+        },
+      });
+
+      (getServerSession as jest.Mock).mockResolvedValueOnce({
+        user: { id: '123' }
+      });
+
+      const existingCourses = {
+        firstQuarter: "20241",
+        courses: [],
+        overrides: [{ type: 'major', requirement: 'specific-course', courseId: 1 }]
+      };
+
+      const updatedCourses = {
+        firstQuarter: "20241",
+        courses: [],
+        overrides: []
+      };
+
+      (prisma.user.findUnique as jest.Mock).mockResolvedValueOnce({
+        courses: existingCourses
+      });
+
+      (prisma.user.update as jest.Mock).mockResolvedValueOnce({
+        courses: updatedCourses
+      });
+
+      await removeOverrideHandler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(JSON.parse(res._getData())).toEqual({
+        overrides: updatedCourses.overrides
+      });
+    });
+
+    it('should remove a ge override successfully', async () => {
+      const { req, res } = createMocks({
+        method: 'POST',
+        body: {
+          override: { type: 'ge', requirement: 'WRT' }
+        },
+      });
+
+      (getServerSession as jest.Mock).mockResolvedValueOnce({
+        user: { id: '123' }
+      });
+
+      const existingCourses = {
+        firstQuarter: "20241",
+        courses: [],
+        overrides: [{ type: 'ge', requirement: 'WRT' }]
+      };
+
+      const updatedCourses = {
+        firstQuarter: "20241",
+        courses: [],
+        overrides: []
+      };
+
+      (prisma.user.findUnique as jest.Mock).mockResolvedValueOnce({
+        courses: existingCourses
+      });
+
+      (prisma.user.update as jest.Mock).mockResolvedValueOnce({
+        courses: updatedCourses
+      });
+
+      await removeOverrideHandler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(JSON.parse(res._getData())).toEqual({
+        overrides: updatedCourses.overrides
+      });
+    });
+
+    it('should return 404 if no matching override is found', async () => {
+      const { req, res } = createMocks({
+        method: 'POST',
+        body: {
+          override: { type: 'major', requirement: 'elective' }
+        },
+      });
+
+      (getServerSession as jest.Mock).mockResolvedValueOnce({
+        user: { id: '123' }
+      });
+
+      const existingCourses = {
+        firstQuarter: "20241",
+        courses: [],
+        overrides: [{ type: 'ge', requirement: 'WRT' }] // Different override
+      };
+
+      (prisma.user.findUnique as jest.Mock).mockResolvedValueOnce({
+        courses: existingCourses
+      });
+
+      await removeOverrideHandler(req, res);
+
+      expect(res._getStatusCode()).toBe(404);
+      expect(JSON.parse(res._getData())).toEqual({
+        error: "No matching override found"
+      });
+    });
+
+    it('should return 400 if override is missing required fields', async () => {
+      const { req, res } = createMocks({
+        method: 'POST',
+        body: {
+          override: { type: 'major' } // Missing requirement field
+        },
+      });
+
+      (getServerSession as jest.Mock).mockResolvedValueOnce({
+        user: { id: '123' }
+      });
+
+      await removeOverrideHandler(req, res);
+
+      expect(res._getStatusCode()).toBe(400);
+      expect(JSON.parse(res._getData())).toEqual({
+        error: "Valid override object is required with type and requirement fields"
       });
     });
   });

--- a/gauchograduate/src/pages/api/user/add-course.ts
+++ b/gauchograduate/src/pages/api/user/add-course.ts
@@ -2,6 +2,7 @@ import { getServerSession } from "next-auth/next"
 import { authOptions } from "../auth/[...nextauth]"
 import { prisma } from "@/lib/prisma"
 import type { NextApiRequest, NextApiResponse } from 'next'
+import { MajorOverride } from "@/types/next-auth"
 
 type ResponseData = {
   error?: string
@@ -43,31 +44,36 @@ export default async function handler(
       return res.status(404).json({ error: "User not found" })
     }
 
-    const userCourses = user.courses as { firstQuarter: string; courses: { id: number; quarter: string }[] }
+    const userCourses = user.courses as unknown as { 
+      firstQuarter: string; 
+      courses: { id: number; quarter: string }[];
+      overrides?: MajorOverride[];
+    }
     
     // Check if course already exists for this quarter
     if (userCourses.courses.some(course => course.id === id && course.quarter === quarter)) {
       return res.status(400).json({ error: "Course already exists in this quarter" })
     }
 
-    // Add the new course
+    // Add the new course while preserving overrides
     const updatedCourses = {
       firstQuarter: userCourses.firstQuarter,
-      courses: [...userCourses.courses, { id, quarter }]
+      courses: [...userCourses.courses, { id, quarter }],
+      overrides: userCourses.overrides || [] // Preserve existing overrides
     }
 
-    // Update the user's courses
+    // Update the user's courses - convert to JSON string and then parse to ensure proper format
     const updatedUser = await prisma.user.update({
       where: { id: session.user.id },
       data: {
-        courses: updatedCourses
+        courses: JSON.parse(JSON.stringify(updatedCourses))
       },
       select: {
         courses: true
       }
     })
 
-    res.json({ courses: updatedUser.courses as { id: string; quarter: string }[] })
+    res.json({ courses: updatedUser.courses as unknown as { id: string; quarter: string }[] })
   } catch (error) {
     console.error('Error adding course:', error)
     res.status(500).json({ error: "Failed to add course" })

--- a/gauchograduate/src/pages/api/user/add-override.ts
+++ b/gauchograduate/src/pages/api/user/add-override.ts
@@ -1,0 +1,108 @@
+import { getServerSession } from "next-auth/next"
+import { authOptions } from "../auth/[...nextauth]"
+import { prisma } from "@/lib/prisma"
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { MajorOverride } from "@/types/next-auth"
+
+type ResponseData = {
+  error?: string
+  overrides?: MajorOverride[]
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ResponseData>
+) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const session = await getServerSession(req, res, authOptions)
+  
+  if (!session?.user?.id) {
+    return res.status(401).json({ error: "Not authenticated" })
+  }
+
+  const override = req.body.override as MajorOverride
+
+  if (!override || typeof override !== 'object') {
+    return res.status(400).json({ error: "Override object is required" })
+  }
+
+  if (!override.type || !override.requirement) {
+    return res.status(400).json({ error: "Override must include 'type' and 'requirement' fields" })
+  }
+
+  if (override.type !== 'major' && override.type !== 'ge') {
+    return res.status(400).json({ error: "Override type must be 'major' or 'ge'" })
+  }
+
+  if (override.type === 'major' && 
+      override.requirement === 'specific-course' && 
+      (override.courseId === undefined || typeof override.courseId !== 'number')) {
+    return res.status(400).json({ error: "courseId is required for specific-course requirements" })
+  }
+
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: session.user.id },
+      select: {
+        courses: true
+      }
+    })
+    
+    if (!user) {
+      return res.status(404).json({ error: "User not found" })
+    }
+
+    const userCourses = user.courses as unknown as { 
+      firstQuarter: string; 
+      courses: { id: number; quarter: string }[];
+      overrides?: MajorOverride[] 
+    }
+    
+    if (!userCourses.overrides) {
+      userCourses.overrides = []
+    }
+    
+    const isDuplicate = userCourses.overrides.some(existing => {
+      if (existing.type !== override.type) return false;
+      if (existing.requirement !== override.requirement) return false;
+      
+      if (override.courseId !== undefined && existing.courseId !== undefined) {
+        return existing.courseId === override.courseId;
+      } else if (override.courseId === undefined && existing.courseId === undefined) {
+        return true;
+      }
+      
+      return false;
+    });
+    
+    if (isDuplicate) {
+      return res.status(400).json({ error: "This override already exists" })
+    }
+    
+    userCourses.overrides.push(override)
+
+    const updatedUser = await prisma.user.update({
+      where: { id: session.user.id },
+      data: {
+        courses: JSON.parse(JSON.stringify(userCourses))
+      },
+      select: {
+        courses: true
+      }
+    })
+
+    const updatedCourses = updatedUser.courses as unknown as { 
+      firstQuarter: string; 
+      courses: { id: number; quarter: string }[];
+      overrides: MajorOverride[] 
+    }
+
+    res.json({ overrides: updatedCourses.overrides })
+  } catch (error) {
+    console.error('Error adding override:', error)
+    res.status(500).json({ error: "Failed to add override" })
+  }
+}

--- a/gauchograduate/src/pages/api/user/courses.ts
+++ b/gauchograduate/src/pages/api/user/courses.ts
@@ -2,6 +2,7 @@ import { getServerSession } from "next-auth/next"
 import { authOptions } from "../auth/[...nextauth]"
 import { prisma } from "@/lib/prisma"
 import type { NextApiRequest, NextApiResponse } from 'next'
+import { UserCourses, MajorOverride } from "@/types/next-auth"
 
 type ResponseData = {
   error?: string
@@ -10,6 +11,7 @@ type ResponseData = {
     id: string;
     quarter: string;
   }[]
+  overrides?: MajorOverride[]
 }
 
 export default async function handler(
@@ -38,7 +40,8 @@ export default async function handler(
       return res.status(404).json({ error: "User not found" })
     }
 
-    const userCourses = user.courses as { firstQuarter: string; courses: { id: string; quarter: string }[] }
+    // Cast to unknown first, then to UserCourses to avoid the type error
+    const userCourses = user.courses as unknown as UserCourses
     res.json(userCourses)
   } catch (error) {
     console.error('Error fetching user courses:', error)

--- a/gauchograduate/src/pages/api/user/courses/set-grade.ts
+++ b/gauchograduate/src/pages/api/user/courses/set-grade.ts
@@ -1,0 +1,108 @@
+import { getServerSession } from "next-auth/next"
+import { authOptions } from "../../auth/[...nextauth]"
+import { prisma } from "@/lib/prisma"
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { MajorOverride } from "@/types/next-auth"
+
+type ResponseData = {
+  error?: string
+  success?: boolean
+  courses?: {
+    id: number;
+    quarter: string;
+    grade?: string;
+  }[]
+}
+
+// Valid grade values
+const VALID_GRADES = [
+  "A+", "A", "A-", 
+  "B+", "B", "B-", 
+  "C+", "C", "C-", 
+  "D+", "D", "D-", 
+  "F", "P", "NP"
+];
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ResponseData>
+) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const session = await getServerSession(req, res, authOptions)
+  
+  if (!session?.user?.id) {
+    return res.status(401).json({ error: "Not authenticated" })
+  }
+
+  const { id, quarter, grade } = req.body
+
+  if (!id || !quarter || typeof id !== 'number' || typeof quarter !== 'string') {
+    return res.status(400).json({ error: "Course ID (number) and quarter (string) are required" })
+  }
+
+  if (grade && !VALID_GRADES.includes(grade)) {
+    return res.status(400).json({ error: `Invalid grade. Valid grades are: ${VALID_GRADES.join(', ')}` })
+  }
+
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: session.user.id },
+      select: {
+        courses: true
+      }
+    })
+    
+    if (!user) {
+      return res.status(404).json({ error: "User not found" })
+    }
+
+    const userCourses = user.courses as unknown as { 
+      firstQuarter: string; 
+      courses: { id: number; quarter: string; grade?: string }[];
+      overrides?: MajorOverride[];
+    }
+    
+    // Find the course to update
+    const courseIndex = userCourses.courses.findIndex(
+      course => course.id === id && course.quarter === quarter
+    );
+    
+    if (courseIndex === -1) {
+      return res.status(404).json({ error: "Course not found in user's course list" })
+    }
+
+    // Update the grade
+    if (grade) {
+      userCourses.courses[courseIndex].grade = grade;
+    } else {
+      // If grade is null or undefined, remove the grade property
+      delete userCourses.courses[courseIndex].grade;
+    }
+
+    // Update the user's courses - convert to JSON string and then parse to ensure proper format
+    const updatedUser = await prisma.user.update({
+      where: { id: session.user.id },
+      data: {
+        courses: JSON.parse(JSON.stringify(userCourses))
+      },
+      select: {
+        courses: true
+      }
+    })
+
+    const updatedCourses = (updatedUser.courses as unknown as { 
+      courses: { id: number; quarter: string; grade?: string }[];
+    }).courses;
+
+    res.json({ 
+      success: true,
+      courses: updatedCourses
+    })
+  } catch (error) {
+    console.error('Error setting course grade:', error)
+    res.status(500).json({ error: "Failed to set course grade" })
+  }
+}

--- a/gauchograduate/src/pages/api/user/remove-course.ts
+++ b/gauchograduate/src/pages/api/user/remove-course.ts
@@ -2,6 +2,7 @@ import { getServerSession } from "next-auth/next"
 import { authOptions } from "../auth/[...nextauth]"
 import { prisma } from "@/lib/prisma"
 import type { NextApiRequest, NextApiResponse } from 'next'
+import { MajorOverride } from "@/types/next-auth"
 
 type ResponseData = {
   error?: string
@@ -43,7 +44,11 @@ export default async function handler(
       return res.status(404).json({ error: "User not found" })
     }
 
-    const userCourses = user.courses as { firstQuarter: string; courses: { id: number; quarter: string }[] }
+    const userCourses = user.courses as unknown as { 
+      firstQuarter: string; 
+      courses: { id: number; quarter: string }[];
+      overrides?: MajorOverride[];
+    }
     
     // Check if course exists in the user's list
     const courseExists = userCourses.courses.some(course => course.id === id && course.quarter === quarter)
@@ -52,26 +57,27 @@ export default async function handler(
       return res.status(400).json({ error: "Course not found in user's course list" })
     }
 
-    // Remove the course
+    // Remove the course while preserving overrides
     const updatedCourses = {
       firstQuarter: userCourses.firstQuarter,
       courses: userCourses.courses.filter(
         course => !(course.id === id && course.quarter === quarter)
-      )
+      ),
+      overrides: userCourses.overrides || [] // Preserve existing overrides
     }
 
-    // Update the user's courses
+    // Update the user's courses - convert to JSON string and then parse to ensure proper format
     const updatedUser = await prisma.user.update({
       where: { id: session.user.id },
       data: {
-        courses: updatedCourses
+        courses: JSON.parse(JSON.stringify(updatedCourses))
       },
       select: {
         courses: true
       }
     })
 
-    res.json({ courses: updatedUser.courses as { id: string; quarter: string }[] })
+    res.json({ courses: updatedUser.courses as unknown as { id: string; quarter: string }[] })
   } catch (error) {
     console.error('Error removing course:', error)
     res.status(500).json({ error: "Failed to remove course" })

--- a/gauchograduate/src/pages/api/user/remove-override.ts
+++ b/gauchograduate/src/pages/api/user/remove-override.ts
@@ -1,0 +1,100 @@
+import { getServerSession } from "next-auth/next"
+import { authOptions } from "../auth/[...nextauth]"
+import { prisma } from "@/lib/prisma"
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { MajorOverride } from "@/types/next-auth"
+
+type ResponseData = {
+  error?: string
+  overrides?: MajorOverride[]
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ResponseData>
+) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const session = await getServerSession(req, res, authOptions)
+  
+  if (!session?.user?.id) {
+    return res.status(401).json({ error: "Not authenticated" })
+  }
+
+  const override = req.body.override as MajorOverride
+
+  if (!override || typeof override !== 'object' || !override.type || !override.requirement) {
+    return res.status(400).json({ error: "Valid override object is required with type and requirement fields" })
+  }
+
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: session.user.id },
+      select: {
+        courses: true
+      }
+    })
+    
+    if (!user) {
+      return res.status(404).json({ error: "User not found" })
+    }
+
+    const userCourses = user.courses as unknown as { 
+      firstQuarter: string; 
+      courses: { id: number; quarter: string }[];
+      overrides?: MajorOverride[] 
+    }
+    
+    // Check if overrides array exists
+    if (!userCourses.overrides || !Array.isArray(userCourses.overrides)) {
+      userCourses.overrides = []
+      return res.status(400).json({ error: "No overrides found" })
+    }
+    
+    // Find the override to remove by matching all properties
+    const initialLength = userCourses.overrides.length;
+    userCourses.overrides = userCourses.overrides.filter(existingOverride => {
+      // Check if all properties match
+      if (existingOverride.type !== override.type) return true;
+      if (existingOverride.requirement !== override.requirement) return true;
+      
+      // For courseId, only compare if both have it or neither has it
+      if (override.courseId !== undefined && existingOverride.courseId !== undefined) {
+        return existingOverride.courseId !== override.courseId;
+      } else if (override.courseId === undefined && existingOverride.courseId === undefined) {
+        return false; // They match (both don't have courseId)
+      }
+      
+      return true; // Keep this override (no match)
+    });
+    
+    // Check if any override was removed
+    if (userCourses.overrides.length === initialLength) {
+      return res.status(404).json({ error: "No matching override found" })
+    }
+
+    // Update the user's courses - convert to JSON string and then parse to ensure proper format
+    const updatedUser = await prisma.user.update({
+      where: { id: session.user.id },
+      data: {
+        courses: JSON.parse(JSON.stringify(userCourses))
+      },
+      select: {
+        courses: true
+      }
+    })
+
+    const updatedCourses = updatedUser.courses as unknown as { 
+      firstQuarter: string; 
+      courses: { id: number; quarter: string }[];
+      overrides: MajorOverride[] 
+    }
+
+    res.json({ overrides: updatedCourses.overrides })
+  } catch (error) {
+    console.error('Error removing override:', error)
+    res.status(500).json({ error: "Failed to remove override" })
+  }
+}

--- a/gauchograduate/src/types/next-auth.d.ts
+++ b/gauchograduate/src/types/next-auth.d.ts
@@ -6,9 +6,16 @@ export interface UserCourse {
   grade?: string;
 }
 
+export interface MajorOverride {
+  type: string;
+  requirement: string;
+  courseId?: number;
+}
+
 export interface UserCourses {
   firstQuarter: string;
   courses: UserCourse[];
+  overrides?: MajorOverride[];
 }
 
 declare module "next-auth" {


### PR DESCRIPTION
Closes #114 
Closes #119 

## Courses set grade API endpoint
You can now set a grade for a course in a user's schedule with the following data:
`POST /api/user/courses/set-grade`
With the following fields `id: <courseId>, quarter: <course quarter>, grade: <letter grade>`. If the endpoint is called with the `grade` field omitted, the grade is removed for that class.
The following are valid letter grades:
"A+", "A", "A-", 
"B+", "B", "B-", 
"C+", "C", "C-", 
"D+", "D", "D-", 
"F", "P", "NP"

## Add Override endpoint
You can add a major requirement override using the following endpoint
`POST /api/user/add-override` with the following data:
`override: {type: <'major' or 'ge'>, requirement: <'specific-course' for a specific course or any other requirement type like 'WRT' for ge writing>, courseId: <IF requirement is set to specific-course, you must provide the course's id here>}`

## Remove Override endpoint
You can remove a major requirement override using the following endpoint
`POST /api/user/remove-override` with the following data:
`override: {same override object format as for adding, needs to match exactly an existing override}`

## Fetching overrides
You can see all the user's overrides by getting their courses, i.e., the `/api/user/courses` endpoint now also provides the overrides.

## Tests
Appropriate tests have been added for all endpoints.