### PR TITLE
Redirect new users to update profile page.

### DIFF
--- a/gauchograduate/src/pages/index.tsx
+++ b/gauchograduate/src/pages/index.tsx
@@ -203,8 +203,13 @@ export default function HomePage() {
   useEffect(() => {
     if (status === "unauthenticated") {
       router.push("/signin");
+    } else if (status === "authenticated" && session?.user) {
+      // Check if user has a major selected
+      if (!session.user.majorId) {
+        router.push("/update-profile");
+      }
     }
-  }, [status, router]);
+  }, [status, router, session]);
 
   const isLoading = isUserCoursesLoading || isSavedScheduleLoading || (!hasEverLoaded && !isUserCoursesError && !isSavedScheduleError);
 


### PR DESCRIPTION
For new users that sign in they will be directed to the update profile page to select a major. This is a one time thing only for new users. If for some reason a existing user doesn't have a major selected then they will be directed to the update profile page.
<img width="1440" alt="Screenshot 2025-02-26 at 3 36 21 PM" src="https://github.com/user-attachments/assets/077d3046-c690-4d33-98e3-b9015a7eaf04" />
Closes #111 